### PR TITLE
Change hashbang

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ##
 # usage: bin/compile <build-dir> <cache-dir>


### PR DESCRIPTION
Change hashbang to bash. Else deploy fails with following message:

``` bash
/tmp/buildpack_26qv4fn40kh5l/bin/compile: 58: Bad substitution
!     Heroku push rejected, failed to compile Erlang app
```
