### PR TITLE
Cache deps/ and ebin/ between builds.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -51,10 +51,18 @@ fi
 
 echo "-----> Building with Rebar"
 unset GIT_DIR
+
+if test -d "${cache}/deps" && test -d "${cache}/ebin"; then
+  cp -a "${cache}/deps" "${cache}/ebin" .
+fi
+
 ./rebar get-deps compile 2>&1 | sed -u 's/^/       /'
 if [ ${PIPESTATUS[0]} -ne 0 ]; then
   echo "-----> Build failed"
   exit 1
 fi
+
+rm -rf "${cache}/deps" "${cache}/ebin"
+cp -a deps ebin "${cache}"
 
 echo "-----> Build succeeded"

--- a/bin/compile
+++ b/bin/compile
@@ -54,9 +54,12 @@ unset GIT_DIR
 
 if test -d "${cache}/deps" && test -d "${cache}/ebin"; then
   cp -a "${cache}/deps" "${cache}/ebin" .
+  deps_command="update-deps"
+else
+  deps_command="get-deps"
 fi
 
-./rebar get-deps compile 2>&1 | sed -u 's/^/       /'
+./rebar "$deps_command" compile 2>&1 | sed -u 's/^/       /'
 if [ ${PIPESTATUS[0]} -ne 0 ]; then
   echo "-----> Build failed"
   exit 1


### PR DESCRIPTION
Opening this for discussion.

I noticed the buildpack wasn't doing any between-build caching other than of the erlang tarball. This is a quick start to cache `deps/` and `ebin/` between builds. Seems to have worked for deps but rebar is compiling the app I'm testing with every time. I tried running it with `-vvv` to see if it would display why it thinks it needs to build things but it didn't help me figure it out at least. Guessing it's something not having its timestamp preserved across builds as rebar might expect.
