### PR TITLE
Add R16 versions to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Currently supported OTP versions:
 * OTP_R15B
 * OTP_R15B01
 * OTP_R15B02
+* OTP_R16B
+* OTP_R16B01
+* OTP_R16B02
 
 To select the version for your app:
 


### PR DESCRIPTION
I can pull down the tarballs for the newer versions from S3, and I see it mentioned in other blog posts that these work, so I've added them to the README.
