### PR TITLE
Cloud foundry compatibility

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -6,7 +6,7 @@ procfile=$(cat Procfile)
 cat << EOF
 ---
 config_vars:
-PATH: /app/otp/bin:bin:/usr/bin:/bin
+	PATH: /app/otp/bin:bin:/usr/bin:/bin
 default_process_types:
-$procfile
+	$procfile
 EOF

--- a/bin/release
+++ b/bin/release
@@ -1,7 +1,12 @@
 #!/bin/sh
+build=$(cd "$1/" && pwd)
+cd $build
+procfile=$(cat Procfile)
 
 cat << EOF
 ---
 config_vars:
-  PATH: /app/otp/bin:bin:/usr/bin:/bin
+PATH: /app/otp/bin:bin:/usr/bin:/bin
+default_process_types:
+$procfile
 EOF

--- a/bin/release
+++ b/bin/release
@@ -6,7 +6,7 @@ procfile=$(cat Procfile)
 cat << EOF
 ---
 config_vars:
-	PATH: /app/otp/bin:bin:/usr/bin:/bin
+  PATH: /app/otp/bin:bin:/usr/bin:/bin
 default_process_types:
-	$procfile
+  $procfile
 EOF


### PR DESCRIPTION
This will make the build pack compatible with Cloud foundry

Small caveat for Cloud Foundry users:
You will need to use the following absolute path to erl in your procfile: /app/otp/bin/erl, ex:

``` yaml
web: /app/otp/bin/erl -pa ebin deps/*/ebin -noshell -noinput -s myapp
```

_/app/opt/bin is in the PATH but for some reason it's not picked up by CF..._
